### PR TITLE
Replace the number of iterations by a pluggable schedule

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hammer-and-sample"
 description = "Simplistic MCMC ensemble sampler based on emcee, the MCMC hammer"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/tests/coin_flip.rs
+++ b/tests/coin_flip.rs
@@ -4,7 +4,7 @@ use rand::{
 };
 use rand_pcg::Pcg64Mcg;
 
-use hammer_and_sample::{auto_corr_time, sample, Model, Serial};
+use hammer_and_sample::{auto_corr_time, sample, MinChainLen, Model, Serial};
 
 #[test]
 fn coin_flip() {
@@ -48,9 +48,9 @@ fn coin_flip() {
         ([guess_p], rng)
     });
 
-    let (chain, accepted) = sample(&model, walkers, 1000, &Serial);
+    let (chain, accepted) = sample(&model, walkers, MinChainLen(100_000), Serial);
 
-    let converged_chain = &chain[100 * 100..];
+    let converged_chain = &chain[10_000..];
 
     let estimated_p =
         converged_chain.iter().map(|params| params[0]).sum::<f64>() / converged_chain.len() as f64;

--- a/tests/hierarchical.rs
+++ b/tests/hierarchical.rs
@@ -2,7 +2,7 @@ use rand::{seq::SliceRandom, SeedableRng};
 use rand_distr::{Bernoulli, Distribution, Normal};
 use rand_pcg::Pcg64Mcg;
 
-use hammer_and_sample::{auto_corr_time, sample, Model, Parallel};
+use hammer_and_sample::{auto_corr_time, sample, MinChainLen, Model, Parallel};
 
 #[test]
 fn hierarchical() {
@@ -116,7 +116,7 @@ fn hierarchical() {
         (guess, rng)
     });
 
-    let (chain, accepted) = sample(&model, walkers, ITERATIONS, &Parallel);
+    let (chain, accepted) = sample(&model, walkers, MinChainLen(WALKERS * ITERATIONS), Parallel);
 
     let converged_chain = &chain[WALKERS * BURN_IN..];
 


### PR DESCRIPTION
This enables additional use cases like running the sampler until some condition based on the chain is fulfilled or reporting progress back to the user.